### PR TITLE
Add support for automatically installing NLS dependencies

### DIFF
--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -161,9 +161,8 @@ then
 fi
 printf "%s\n" ", done."
 git clone https://github.com/Saxfordshire/natural-language-shell.git $HOME/"Natural Language Shell" --depth 1
-printf "%s" "Building Go package (your password may be required)"
-$(cd $HOME/"Natural Language Shell" && go build -o /usr/local/bin/nls)
-printf "%s\n" ", done."
+printf "%s\n" "Building Go package (your password may be required)..."
+$(cd $HOME/"Natural Language Shell" && sudo go build -o /usr/local/bin/nls)
 printf "%s" "Removing build files"
 rm -rf $HOME/"Natural Language Shell"
 printf "%s\n" ", done."

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -104,6 +104,11 @@ if ! command -v go &> /dev/null; then
             printf "%s\n" "autoinstall: unable to install Go for Mac. Please follow the instructions at https://git-scm.com/download/mac"
         fi
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # Ordered alphabetically with universal package managers first, then 
+        # distro-specific pacage managers after to avoid potential conflicts
+        elif command -v snap &> /dev/null; then
+            sudo snap install go
+            printf "%s\n" ", done."
         if command -v apk &> /dev/null; then 
             apk add go
             printf "%s\n" ", done."
@@ -124,9 +129,6 @@ if ! command -v go &> /dev/null; then
             printf "%s\n" ", done."
         elif command -v pacman &> /dev/null; then
             sudo pacman -S go
-            printf "%s\n" ", done."
-        elif command -v snap &> /dev/null; then
-            sudo snap install go
             printf "%s\n" ", done."
         elif command -v urpmi &> /dev/null; then
             sudo urpmi go

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -88,11 +88,90 @@ else
     printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: checking Go installation"
-if ! command -v go &> /dev/null
-then
-    printf "%s\n" "autoinstall: Go could not be found, please install Go"
+if ! command -v git &> /dev/null; then
+    printf "%s\n" ", done."
+    printf "%s" "autointall: installing Go"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &> /dev/null; then
+            brew install go
+            printf "%s\n" ", done."
+        elif ! command -v brew &> /dev/null; then
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            brew install go
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Go for Mac. Please follow the instructions at https://git-scm.com/download/mac"
+        fi
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if command -v apk &> /dev/null; then 
+            apk add go
+            printf "%s\n" ", done."
+        elif command -v apt-get &> /dev/null; then
+            sudo apt-get install go
+            printf "%s\n" ", done."
+        elif command -v brew &> /dev/null; then
+            brew install go
+            printf "%s\n" ", done."
+        elif command -v dnf &> /dev/null; then
+            sudo dnf install go
+            printf "%s\n" ", done."
+        elif command -v emerge &> /dev/null; then
+            sudo emerge --ask --verbose dev-vcs/git
+            printf "%s\n" ", done."
+        elif command -v nix-env &> /dev/null; then
+            sudo nix-env -i go
+            printf "%s\n" ", done."
+        elif command -v pacman &> /dev/null; then
+            sudo pacman -S go
+            printf "%s\n" ", done."
+        elif command -v urpmi &> /dev/null; then
+            sudo urpmi go
+            printf "%s\n" ", done."
+        elif command -v yum &> /dev/null; then
+            sudo yum install go
+            printf "%s\n" ", done."
+        elif command -v zypper &> /dev/null; then
+            sudo zypper install go
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for Linux. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
+        if command -v zypper &> /dev/null; then
+            sudo zypper install go
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "solaris"* ]]; then
+        if command -v pkgutil &> /dev/null; then
+            sudo pkgutil -i go
+            printf "%s\n" ", done."
+        elif command -v pkg &> /dev/null; then
+            sudo pkg install developer/versioning/go
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "openbsd"* ]]; then
+        if command -v pkg_add &> /dev/null; then
+            sudo pkg_add go
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for OpenBSD. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    else
+        printf "%s\n" ", error!"
+        printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
+    fi
+else
+    printf "%s\n" ", done."
 fi
-printf "%s\n" ", done."
 printf "%s" "autoinstall: checking Python 3 installation"
 if ! command -v python3 &> /dev/null
 then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -90,7 +90,7 @@ fi
 printf "%s" "autoinstall: checking Go installation"
 if ! command -v go &> /dev/null; then
     printf "%s\n" ", done."
-    printf "%s" "autointall: installing Go"
+    printf "%s\n" "autointall: installing Go..."
     if [[ "$OSTYPE" == "darwin"* ]]; then
         if command -v brew &> /dev/null; then
             brew install go
@@ -107,7 +107,7 @@ if ! command -v go &> /dev/null; then
         # Ordered alphabetically with universal package managers first, then 
         # distro-specific pacage managers after to avoid potential conflicts
         if command -v snap &> /dev/null; then
-            sudo snap install go
+            sudo snap install go --classic
             printf "%s\n" ", done."
         elif command -v apk &> /dev/null; then 
             apk add go

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -125,6 +125,9 @@ if ! command -v go &> /dev/null; then
         elif command -v pacman &> /dev/null; then
             sudo pacman -S go
             printf "%s\n" ", done."
+        elif command -v snap &> /dev/null; then
+            sudo snap install go
+            printf "%s\n" ", done."
         elif command -v urpmi &> /dev/null; then
             sudo urpmi go
             printf "%s\n" ", done."

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -1,18 +1,94 @@
-#! /bin/sh
+#! /bin/bash
 printf "%s\n" "Welcome to NLS! The installation will begin soon."
+rm -rf $HOME/"Natural Language Shell"
 printf "%s\n" "Verifying dependencies..."
 printf "%s" "autoinstall: checking Git installation"
-if [ ! command -v git &> /dev/null ]
-then
-    echo "autointall: Git could not be found, please install Git"
-    exit
+if [ ! command -v git &> /dev/null ]; then
+    printf "%s\n" ", done."
+    printf "%s" "autointall: installing Git"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if [ command -v brew &> /dev/null ]; then
+            brew install git
+            printf "%s\n" ", done."
+        elif [ ! command -v brew &> /dev/null ]; then
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            brew install git
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for Mac. Please follow the instructions at https://git-scm.com/download/mac"
+        fi
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if [ command -v apk &> /dev/null ]; then 
+            apk add git
+            printf "%s\n" ", done."
+        elif [ command -v apt-get &> /dev/null ]; then
+            sudo apt-get install git
+            printf "%s\n" ", done."
+        elif [ command -v brew &> /dev/null ]; then
+            brew install git
+            printf "%s\n" ", done."
+        elif [ command -v dnf &> /dev/null ]; then
+            sudo dnf install git
+            printf "%s\n" ", done."
+        elif [ command -v emerge &> /dev/null ]; then
+            sudo emerge --ask --verbose dev-vcs/git
+            printf "%s\n" ", done."
+        elif [ command -v nix-env &> /dev/null ]; then
+            sudo nix-env -i git
+            printf "%s\n" ", done."
+        elif [ command -v pacman &> /dev/null ]; then
+            sudo pacman -S git
+            printf "%s\n" ", done."
+        elif [ command -v urpmi &> /dev/null ]; then
+            sudo urpmi git
+            printf "%s\n" ", done."
+        elif [ command -v yum &> /dev/null ]; then
+            sudo yum install git
+            printf "%s\n" ", done."
+        elif [ command -v zypper &> /dev/null ]; then
+            sudo zypper install git
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for Linux. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
+        if [ command -v zypper &> /dev/null ]; then
+            sudo zypper install git
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "solaris"* ]]; then
+        if [ command -v pkgutil &> /dev/null ]; then
+            sudo pkgutil -i git
+            printf "%s\n" ", done."
+        elif [ command -v pkg &> /dev/null ]; then
+            sudo pkg install developer/versioning/git
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "openbsd"* ]]; then
+        if [ command -v pkg_add &> /dev/null ]; then
+            sudo pkg_add git
+            printf "%s\n" ", done."
+        else
+            printf "%s\n" ", error!"
+            printf "%s\n" "autoinstall: unable to install Git for OpenBSD. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    else
+        printf "%s\n" ", error!"
+        printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
+    fi
 fi
-printf "%s\n" ", done."
 printf "%s" "autoinstall: checking Go installation"
 if [ ! command -v go &> /dev/null ]
 then
     printf "%s\n" "autoinstall: Go could not be found, please install Go"
-    exit
 fi
 printf "%s\n" ", done."
 printf "%s" "autoinstall: checking Python 3 installation"
@@ -20,8 +96,7 @@ if [ ! command -v python3 &> /dev/null ]
 then
     printf "%s\n" "autoinstall: Python 3 could not be found, it isn't required"
     printf "%s\n" "             but consider installing Python 3 for additional"
-    printf "%s\n" "             functionality."
-    exit
+    printf "%s\n" "             functionality." 
 fi
 printf "%s\n" ", done."
 git clone https://github.com/Saxfordshire/natural-language-shell.git $HOME/"Natural Language Shell" --depth 1

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -199,7 +199,6 @@ if ! command -v go &> /dev/null; then
 else
     printf "%s\n" ", done."
 fi
-printf "%s\n" ", done."
 git clone https://github.com/Saxfordshire/natural-language-shell.git $HOME/"Natural Language Shell" --depth 1
 printf "%s\n" "Building Go package (your password may be required)..."
 $(cd $HOME/"Natural Language Shell" && sudo go build -o /usr/local/bin/nls)

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -64,6 +64,8 @@ if ! command -v git &> /dev/null; then
     else
         printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
     fi
+else
+    printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: verifying Go installation"
 if ! command -v go &> /dev/null; then
@@ -129,6 +131,8 @@ if ! command -v go &> /dev/null; then
     else
         printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
     fi
+else
+    printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: verifying Python 3 installation"
 if ! command -v python3 &> /dev/null

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -135,11 +135,69 @@ else
     printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: verifying Python 3 installation"
-if ! command -v python3 &> /dev/null
-then
-    printf "%s\n" "autoinstall: Python 3 could not be found, it isn't required"
-    printf "%s\n" "             but consider installing Python 3 for additional"
-    printf "%s\n" "             functionality." 
+if ! command -v go &> /dev/null; then
+    printf "%s\n" ", done."
+    printf "%s\n" "autoinstall: installing Python 3..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &> /dev/null; then
+            brew install python3
+        elif ! command -v brew &> /dev/null; then
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            brew install python3
+        else
+            printf "%s\n" "autoinstall: unable to install Python 3 for Mac. Please follow the instructions at https://git-scm.com/download/mac"
+        fi
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # Ordered alphabetically with universal package managers first, then 
+        # distro-specific pacage managers after to avoid potential conflicts
+        elif command -v apk &> /dev/null; then 
+            apk add python3
+        elif command -v apt-get &> /dev/null; then
+            sudo apt-get install python3
+        elif command -v brew &> /dev/null; then
+            brew install python3
+        elif command -v dnf &> /dev/null; then
+            sudo dnf install python3
+        elif command -v emerge &> /dev/null; then
+            sudo emerge --ask --verbose dev-vcs/python3
+        elif command -v nix-env &> /dev/null; then
+            sudo nix-env -i python3
+        elif command -v pacman &> /dev/null; then
+            sudo pacman -S python3
+        elif command -v urpmi &> /dev/null; then
+            sudo urpmi python3
+        elif command -v yum &> /dev/null; then
+            sudo yum install python3
+        elif command -v zypper &> /dev/null; then
+            sudo zypper install python3
+        else
+            printf "%s\n" "autoinstall: unable to install Python 3 for Linux. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
+        if command -v zypper &> /dev/null; then
+            sudo zypper install python3
+        else
+            printf "%s\n" "autoinstall: unable to install Python 3 for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "solaris"* ]]; then
+        if command -v pkgutil &> /dev/null; then
+            sudo pkgutil -i python3
+        elif command -v pkg &> /dev/null; then
+            sudo pkg install developer/versioning/python3
+        else
+            printf "%s\n" "autoinstall: unable to install Python 3 for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    elif [[ "$OSTYPE" == "openbsd"* ]]; then
+        if command -v pkg_add &> /dev/null; then
+            sudo pkg_add python3
+        else
+            printf "%s\n" "autoinstall: unable to install Python 3 for OpenBSD. Please follow the instructions at https://git-scm.com/download/linux"
+        fi
+    else
+        printf "%s\n" "autoinstall: unable to install Python 3. Please follow the instructions at https://git-scm.com/download"
+    fi
+else
+    printf "%s\n" ", done."
 fi
 printf "%s\n" ", done."
 git clone https://github.com/Saxfordshire/natural-language-shell.git $HOME/"Natural Language Shell" --depth 1

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -3,14 +3,14 @@ printf "%s\n" "Welcome to NLS! The installation will begin soon."
 rm -rf $HOME/"Natural Language Shell"
 printf "%s\n" "Verifying dependencies..."
 printf "%s" "autoinstall: checking Git installation"
-if [ ! command -v git &> /dev/null ]; then
+if ! command -v git &> /dev/null; then
     printf "%s\n" ", done."
     printf "%s" "autointall: installing Git"
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        if [ command -v brew &> /dev/null ]; then
+        if command -v brew &> /dev/null; then
             brew install git
             printf "%s\n" ", done."
-        elif [ ! command -v brew &> /dev/null ]; then
+        elif ! command -v brew &> /dev/null; then
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             brew install git
             printf "%s\n" ", done."
@@ -19,34 +19,34 @@ if [ ! command -v git &> /dev/null ]; then
             printf "%s\n" "autoinstall: unable to install Git for Mac. Please follow the instructions at https://git-scm.com/download/mac"
         fi
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        if [ command -v apk &> /dev/null ]; then 
+        if command -v apk &> /dev/null; then 
             apk add git
             printf "%s\n" ", done."
-        elif [ command -v apt-get &> /dev/null ]; then
+        elif command -v apt-get &> /dev/null; then
             sudo apt-get install git
             printf "%s\n" ", done."
-        elif [ command -v brew &> /dev/null ]; then
+        elif command -v brew &> /dev/null; then
             brew install git
             printf "%s\n" ", done."
-        elif [ command -v dnf &> /dev/null ]; then
+        elif command -v dnf &> /dev/null; then
             sudo dnf install git
             printf "%s\n" ", done."
-        elif [ command -v emerge &> /dev/null ]; then
+        elif command -v emerge &> /dev/null; then
             sudo emerge --ask --verbose dev-vcs/git
             printf "%s\n" ", done."
-        elif [ command -v nix-env &> /dev/null ]; then
+        elif command -v nix-env &> /dev/null; then
             sudo nix-env -i git
             printf "%s\n" ", done."
-        elif [ command -v pacman &> /dev/null ]; then
+        elif command -v pacman &> /dev/null; then
             sudo pacman -S git
             printf "%s\n" ", done."
-        elif [ command -v urpmi &> /dev/null ]; then
+        elif command -v urpmi &> /dev/null; then
             sudo urpmi git
             printf "%s\n" ", done."
-        elif [ command -v yum &> /dev/null ]; then
+        elif command -v yum &> /dev/null; then
             sudo yum install git
             printf "%s\n" ", done."
-        elif [ command -v zypper &> /dev/null ]; then
+        elif command -v zypper &> /dev/null; then
             sudo zypper install git
             printf "%s\n" ", done."
         else
@@ -54,7 +54,7 @@ if [ ! command -v git &> /dev/null ]; then
             printf "%s\n" "autoinstall: unable to install Git for Linux. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
-        if [ command -v zypper &> /dev/null ]; then
+        if command -v zypper &> /dev/null; then
             sudo zypper install git
             printf "%s\n" ", done."
         else
@@ -62,10 +62,10 @@ if [ ! command -v git &> /dev/null ]; then
             printf "%s\n" "autoinstall: unable to install Git for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "solaris"* ]]; then
-        if [ command -v pkgutil &> /dev/null ]; then
+        if command -v pkgutil &> /dev/null; then
             sudo pkgutil -i git
             printf "%s\n" ", done."
-        elif [ command -v pkg &> /dev/null ]; then
+        elif command -v pkg &> /dev/null; then
             sudo pkg install developer/versioning/git
             printf "%s\n" ", done."
         else
@@ -73,7 +73,7 @@ if [ ! command -v git &> /dev/null ]; then
             printf "%s\n" "autoinstall: unable to install Git for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "openbsd"* ]]; then
-        if [ command -v pkg_add &> /dev/null ]; then
+        if command -v pkg_add &> /dev/null; then
             sudo pkg_add git
             printf "%s\n" ", done."
         else
@@ -86,13 +86,13 @@ if [ ! command -v git &> /dev/null ]; then
     fi
 fi
 printf "%s" "autoinstall: checking Go installation"
-if [ ! command -v go &> /dev/null ]
+if ! command -v go &> /dev/null
 then
     printf "%s\n" "autoinstall: Go could not be found, please install Go"
 fi
 printf "%s\n" ", done."
 printf "%s" "autoinstall: checking Python 3 installation"
-if [ ! command -v python3 &> /dev/null ]
+if ! command -v python3 &> /dev/null
 then
     printf "%s\n" "autoinstall: Python 3 could not be found, it isn't required"
     printf "%s\n" "             but consider installing Python 3 for additional"

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -2,7 +2,7 @@
 printf "%s\n" "Welcome to NLS! The installation will begin soon."
 rm -rf $HOME/"Natural Language Shell"
 printf "%s\n" "Verifying dependencies..."
-printf "%s" "autoinstall: checking Git installation"
+printf "%s" "autoinstall: verifying Git installation"
 if ! command -v git &> /dev/null; then
     printf "%s\n" ", done."
     printf "%s" "autointall: installing Git"
@@ -87,20 +87,17 @@ if ! command -v git &> /dev/null; then
 else
     printf "%s\n" ", done."
 fi
-printf "%s" "autoinstall: checking Go installation"
+printf "%s" "autoinstall: verifying Go installation"
 if ! command -v go &> /dev/null; then
     printf "%s\n" ", done."
-    printf "%s\n" "autointall: installing Go..."
+    printf "%s\n" "autoinstall: installing Go..."
     if [[ "$OSTYPE" == "darwin"* ]]; then
         if command -v brew &> /dev/null; then
             brew install go
-            printf "%s\n" ", done."
         elif ! command -v brew &> /dev/null; then
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             brew install go
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Go for Mac. Please follow the instructions at https://git-scm.com/download/mac"
         fi
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -108,76 +105,54 @@ if ! command -v go &> /dev/null; then
         # distro-specific pacage managers after to avoid potential conflicts
         if command -v snap &> /dev/null; then
             sudo snap install go --classic
-            printf "%s\n" ", done."
         elif command -v apk &> /dev/null; then 
             apk add go
-            printf "%s\n" ", done."
         elif command -v apt-get &> /dev/null; then
             sudo apt-get install go
-            printf "%s\n" ", done."
         elif command -v brew &> /dev/null; then
             brew install go
-            printf "%s\n" ", done."
         elif command -v dnf &> /dev/null; then
             sudo dnf install go
-            printf "%s\n" ", done."
         elif command -v emerge &> /dev/null; then
             sudo emerge --ask --verbose dev-vcs/git
-            printf "%s\n" ", done."
         elif command -v nix-env &> /dev/null; then
             sudo nix-env -i go
-            printf "%s\n" ", done."
         elif command -v pacman &> /dev/null; then
             sudo pacman -S go
-            printf "%s\n" ", done."
         elif command -v urpmi &> /dev/null; then
             sudo urpmi go
-            printf "%s\n" ", done."
         elif command -v yum &> /dev/null; then
             sudo yum install go
-            printf "%s\n" ", done."
         elif command -v zypper &> /dev/null; then
             sudo zypper install go
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for Linux. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
         if command -v zypper &> /dev/null; then
             sudo zypper install go
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "solaris"* ]]; then
         if command -v pkgutil &> /dev/null; then
             sudo pkgutil -i go
-            printf "%s\n" ", done."
         elif command -v pkg &> /dev/null; then
             sudo pkg install developer/versioning/go
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "openbsd"* ]]; then
         if command -v pkg_add &> /dev/null; then
             sudo pkg_add go
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for OpenBSD. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     else
-        printf "%s\n" ", error!"
         printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
     fi
-else
-    printf "%s\n" ", done."
 fi
-printf "%s" "autoinstall: checking Python 3 installation"
+printf "%s" "autoinstall: verifying Python 3 installation"
 if ! command -v python3 &> /dev/null
 then
     printf "%s\n" "autoinstall: Python 3 could not be found, it isn't required"

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -84,6 +84,8 @@ if ! command -v git &> /dev/null; then
         printf "%s\n" ", error!"
         printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
     fi
+else
+    printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: checking Go installation"
 if ! command -v go &> /dev/null

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -88,7 +88,7 @@ else
     printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: checking Go installation"
-if ! command -v git &> /dev/null; then
+if ! command -v go &> /dev/null; then
     printf "%s\n" ", done."
     printf "%s" "autointall: installing Go"
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -5,87 +5,65 @@ printf "%s\n" "Verifying dependencies..."
 printf "%s" "autoinstall: verifying Git installation"
 if ! command -v git &> /dev/null; then
     printf "%s\n" ", done."
-    printf "%s" "autointall: installing Git"
+    printf "%s\n" "autointall: installing Git..."
     if [[ "$OSTYPE" == "darwin"* ]]; then
         if command -v brew &> /dev/null; then
             brew install git
-            printf "%s\n" ", done."
         elif ! command -v brew &> /dev/null; then
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             brew install git
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for Mac. Please follow the instructions at https://git-scm.com/download/mac"
         fi
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
         if command -v apk &> /dev/null; then 
             apk add git
-            printf "%s\n" ", done."
+        elif command -v apt-get &> /dev/null; then
+            sudo apt install git
         elif command -v apt-get &> /dev/null; then
             sudo apt-get install git
-            printf "%s\n" ", done."
         elif command -v brew &> /dev/null; then
             brew install git
-            printf "%s\n" ", done."
         elif command -v dnf &> /dev/null; then
             sudo dnf install git
-            printf "%s\n" ", done."
         elif command -v emerge &> /dev/null; then
             sudo emerge --ask --verbose dev-vcs/git
-            printf "%s\n" ", done."
         elif command -v nix-env &> /dev/null; then
             sudo nix-env -i git
-            printf "%s\n" ", done."
         elif command -v pacman &> /dev/null; then
             sudo pacman -S git
-            printf "%s\n" ", done."
         elif command -v urpmi &> /dev/null; then
             sudo urpmi git
-            printf "%s\n" ", done."
         elif command -v yum &> /dev/null; then
             sudo yum install git
-            printf "%s\n" ", done."
         elif command -v zypper &> /dev/null; then
             sudo zypper install git
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for Linux. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
         if command -v zypper &> /dev/null; then
             sudo zypper install git
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "solaris"* ]]; then
         if command -v pkgutil &> /dev/null; then
             sudo pkgutil -i git
-            printf "%s\n" ", done."
         elif command -v pkg &> /dev/null; then
             sudo pkg install developer/versioning/git
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     elif [[ "$OSTYPE" == "openbsd"* ]]; then
         if command -v pkg_add &> /dev/null; then
             sudo pkg_add git
-            printf "%s\n" ", done."
         else
-            printf "%s\n" ", error!"
             printf "%s\n" "autoinstall: unable to install Git for OpenBSD. Please follow the instructions at https://git-scm.com/download/linux"
         fi
     else
-        printf "%s\n" ", error!"
         printf "%s\n" "autoinstall: unable to install Git. Please follow the instructions at https://git-scm.com/download"
     fi
-else
-    printf "%s\n" ", done."
 fi
 printf "%s" "autoinstall: verifying Go installation"
 if ! command -v go &> /dev/null; then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -106,10 +106,10 @@ if ! command -v go &> /dev/null; then
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
         # Ordered alphabetically with universal package managers first, then 
         # distro-specific pacage managers after to avoid potential conflicts
-        elif command -v snap &> /dev/null; then
+        if command -v snap &> /dev/null; then
             sudo snap install go
             printf "%s\n" ", done."
-        if command -v apk &> /dev/null; then 
+        elif command -v apk &> /dev/null; then 
             apk add go
             printf "%s\n" ", done."
         elif command -v apt-get &> /dev/null; then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -145,12 +145,12 @@ if ! command -v go &> /dev/null; then
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             brew install python3
         else
-            printf "%s\n" "autoinstall: unable to install Python 3 for Mac. Please follow the instructions at https://git-scm.com/download/mac"
+            printf "%s\n" "autoinstall: unable to install Python 3 for Mac. Please follow the instructions at https://www.python.org/downloads/"
         fi
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
         # Ordered alphabetically with universal package managers first, then 
         # distro-specific pacage managers after to avoid potential conflicts
-        elif command -v apk &> /dev/null; then 
+        if command -v apk &> /dev/null; then 
             apk add python3
         elif command -v apt-get &> /dev/null; then
             sudo apt-get install python3
@@ -171,13 +171,13 @@ if ! command -v go &> /dev/null; then
         elif command -v zypper &> /dev/null; then
             sudo zypper install python3
         else
-            printf "%s\n" "autoinstall: unable to install Python 3 for Linux. Please follow the instructions at https://git-scm.com/download/linux"
+            printf "%s\n" "autoinstall: unable to install Python 3 for Linux. Please follow the instructions at https://www.python.org/downloads/"
         fi
     elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
         if command -v zypper &> /dev/null; then
             sudo zypper install python3
         else
-            printf "%s\n" "autoinstall: unable to install Python 3 for FreeBSD. Please follow the instructions at https://git-scm.com/download/linux"
+            printf "%s\n" "autoinstall: unable to install Python 3 for FreeBSD. Please follow the instructions at https://www.python.org/downloads/"
         fi
     elif [[ "$OSTYPE" == "solaris"* ]]; then
         if command -v pkgutil &> /dev/null; then
@@ -185,16 +185,16 @@ if ! command -v go &> /dev/null; then
         elif command -v pkg &> /dev/null; then
             sudo pkg install developer/versioning/python3
         else
-            printf "%s\n" "autoinstall: unable to install Python 3 for Solaris. Please follow the instructions at https://git-scm.com/download/linux"
+            printf "%s\n" "autoinstall: unable to install Python 3 for Solaris. Please follow the instructions at https://www.python.org/downloads/"
         fi
     elif [[ "$OSTYPE" == "openbsd"* ]]; then
         if command -v pkg_add &> /dev/null; then
             sudo pkg_add python3
         else
-            printf "%s\n" "autoinstall: unable to install Python 3 for OpenBSD. Please follow the instructions at https://git-scm.com/download/linux"
+            printf "%s\n" "autoinstall: unable to install Python 3 for OpenBSD. Please follow the instructions at https://www.python.org/downloads/"
         fi
     else
-        printf "%s\n" "autoinstall: unable to install Python 3. Please follow the instructions at https://git-scm.com/download"
+        printf "%s\n" "autoinstall: unable to install Python 3. Please follow the instructions at https://www.python.org/downloads/"
     fi
 else
     printf "%s\n" ", done."


### PR DESCRIPTION
autoinstall.sh now automatically installs Git, Go, and Python 3 if they aren't already installed.